### PR TITLE
fix: 동적 API 응답에 Cache-Control: no-store 적용

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -39,5 +39,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ['/admin/:path*', '/login', '/api/((?!storage|auth).*)'],
+  matcher: ['/admin/:path*', '/login', '/api/((?!storage(?:/|$)|auth(?:/|$)).*)']
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,9 +2,11 @@ import { auth } from '@/lib/auth';
 import { NextResponse } from 'next/server';
 
 export default auth((req) => {
+  const { pathname } = req.nextUrl;
   const isAuth = !!req.auth;
-  const isAuthPage = req.nextUrl.pathname.startsWith('/login');
-  const isAdminPage = req.nextUrl.pathname.startsWith('/admin');
+  const isAuthPage = pathname.startsWith('/login');
+  const isAdminPage = pathname.startsWith('/admin');
+  const isApi = pathname.startsWith('/api');
 
   if (isAuthPage) {
     if (isAuth) {
@@ -14,7 +16,7 @@ export default auth((req) => {
   }
 
   if (isAdminPage && !isAuth) {
-    let from = req.nextUrl.pathname;
+    let from = pathname;
     if (req.nextUrl.search) {
       from += req.nextUrl.search;
     }
@@ -24,9 +26,18 @@ export default auth((req) => {
     );
   }
 
-  return NextResponse.next();
+  const res = NextResponse.next();
+
+  // 동적 API 응답은 절대 캐시되면 안 됨. Cache-Control이 없으면
+  // Cloudflare가 캐시 가능한 응답으로 보고 max-age를 붙여 stale 응답을 서빙한다.
+  // (정적 파일을 서빙하는 /api/storage와 next-auth /api/auth는 matcher에서 제외)
+  if (isApi) {
+    res.headers.set('Cache-Control', 'no-store');
+  }
+
+  return res;
 });
 
 export const config = {
-  matcher: ['/admin/:path*', '/login'],
+  matcher: ['/admin/:path*', '/login', '/api/((?!storage|auth).*)'],
 };


### PR DESCRIPTION
## 배경

운영 환경에서 `/api/categories` 등 일부 API 응답이 최신화되지 않는 현상.

- 오리진(Next 앱)은 해당 라우트에 `Cache-Control`을 보내지 않음
- 헤더가 없는 응답을 Cloudflare가 캐시 가능으로 판단 → `max-age=43200`(12h) 부여 후 엣지 캐싱 (`cf-cache-status: HIT`)
- 반면 `no-store`를 내려주는 경로(루트, 404 등)는 정상 BYPASS
- 기존 `middleware.ts`는 `/admin`, `/login` 에만 동작 → `/api`에 `no-store`를 붙이는 주체가 없음

## 변경

- 미들웨어 matcher를 `/api`로 확장 (정적 캐시가 필요한 `/api/storage`, next-auth `/api/auth` 는 제외)
- 대상 API 응답에 `Cache-Control: no-store` 주입
- 라우트별 개별 수정 없이 신규 API도 자동 적용

## 배포 후

1. Cloudflare 캐시 1회 퍼지 (`gallery.jihun.io/api/*`) — 기존 잔재 제거
2. 검증: `curl -sD- -o/dev/null https://gallery.jihun.io/api/categories | grep -iE 'cf-cache-status|cache-control'`
   → `cache-control: no-store` + `cf-cache-status: DYNAMIC` 확인